### PR TITLE
recreate DB after failed git pull origin-command

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ MONGO_URI = mongodb://northUser:bGJucFTFliN8qX2Z@ac-gkbjsml-shard-00-00.oxafelt.mongodb.net:27017,ac-gkbjsml-shard-00-01.oxafelt.mongodb.net:27017,ac-gkbjsml-shard-00-02.oxafelt.mongodb.net:27017/?ssl=true&replicaSet=atlas-yrtq9t-shard-0&authSource=admin&retryWrites=true&w=majority

--- a/models/booking.ts
+++ b/models/booking.ts
@@ -1,0 +1,21 @@
+import { Schema, model, models } from "mongoose";
+
+export interface IBooking {
+  userID: string | null; // string = inloggad | null = ej inloggad
+  email: string;
+  movieTitle: string;
+  date: Date;
+  seats: number[];
+}
+
+const bookingSchema = new Schema<IBooking>({
+  userID: Schema.Types.Mixed,
+  email: String,
+  movieTitle: String,
+  date: Date,
+  seats: [Number],
+});
+
+const Booking = models.Booking || model<IBooking>("Booking", bookingSchema);
+
+export default Booking;

--- a/models/movie.ts
+++ b/models/movie.ts
@@ -1,0 +1,37 @@
+import { Schema, model, models } from "mongoose";
+
+export interface IMovie {
+  title: string;
+  description: string;
+  imgUrl: string;
+  duration: number;
+  screenings: Date[];
+  reviews: [
+    {
+      reviewerName: string;
+      reviewerText: string;
+      postDate: Date;
+      rating: number;
+    }
+  ];
+}
+
+const movieSchema = new Schema<IMovie>({
+  title: { type: String, required: true },
+  description: { type: String, required: true },
+  imgUrl: { type: String, required: true },
+  duration: { type: Number, required: true },
+  screenings: [Date],
+  reviews: [
+    {
+      reviewerName: { type: String, required: true },
+      reviewerText: { type: String, required: true },
+      postDate: { type: Date, required: true },
+      rating: { type: Number, min: 1, max: 5, required: true },
+    },
+  ],
+});
+
+const Movie = models.Movie || model<IMovie>("Movie", movieSchema);
+
+export default Movie;

--- a/models/post_template.json
+++ b/models/post_template.json
@@ -1,0 +1,28 @@
+{
+  "MOVIE": {
+    "title": "Shrek",
+    "description": "En film om en grön gubbe",
+    "imgUrl": "https://i-viaplay-com.akamaized.net/viaplay-prod/993/800/1613762117-f07774c22a81b35740522f9e1b18e1e03331bc19.jpg?width=400&height=600",
+    "duration": "86",
+    "screenings": [],
+    "reviews": []
+  },
+
+  "USER": {
+    "name": {
+      "first": "john",
+      "last": "doe"
+    },
+    "userName": "JohnDoe123",
+    "email": "johndoe@gmail.com",
+    "passwordHash": "abc123"
+  },
+
+  "BOOKING": {
+    "userID": "user123",
+    "email": "user123@gmail.com",
+    "movieTitle": "Shrek",
+    "date": "2023-05-12",
+    "seats": [22, 23, 24]
+  }
+}

--- a/models/user.ts
+++ b/models/user.ts
@@ -1,0 +1,25 @@
+import { Schema, model, models } from "mongoose";
+
+export interface IUser {
+  name: {
+    first: string;
+    last: string;
+  };
+  userName: string;
+  email: string;
+  passwordHash: string;
+}
+
+const userSchema = new Schema<IUser>({
+  name: {
+    first: { type: String, required: true },
+    last: { type: String, required: true },
+  },
+  userName: { type: String, required: true},
+  email: { type: String, required: true },
+  passwordHash: { type: String, required: true },
+});
+
+const User = models.User || model<IUser>("User", userSchema);
+
+export default User;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bootstrap": "^5.2.3",
         "eslint": "8.39.0",
         "eslint-config-next": "13.3.1",
+        "mongoose": "^7.1.1",
         "next": "13.3.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -374,6 +375,20 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
@@ -716,6 +731,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bson": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag==",
+      "engines": {
+        "node": ">=14.20.1"
       }
     },
     "node_modules/busboy": {
@@ -1956,6 +1979,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -2329,6 +2357,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -2395,6 +2431,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2432,6 +2474,92 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
+      "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
+      "dependencies": {
+        "bson": "^5.2.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.201.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.1.1.tgz",
+      "integrity": "sha512-AIxaWwGY+td7QOMk4NgK6fbRuGovFyDzv65nU1uj1DsUh3lpjfP3iFYHSR+sUKrs7nbp19ksLlRXkmInBteSCA==",
+      "dependencies": {
+        "bson": "^5.2.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.3.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -2976,6 +3104,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sass": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
@@ -3046,6 +3186,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3054,12 +3199,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -3263,6 +3439,17 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -3365,6 +3552,26 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -3682,6 +3889,20 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
     "@typescript-eslint/parser": {
       "version": "5.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
@@ -3902,6 +4123,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "bson": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.3.0.tgz",
+      "integrity": "sha512-ukmCZMneMlaC5ebPHXIkP8YJzNl5DC41N5MAIvKDqLggdao342t4McltoJBQfQya/nHBWAcSsYRqlXPoQkTJag=="
     },
     "busboy": {
       "version": "1.6.0",
@@ -4809,6 +5035,11 @@
         "side-channel": "^1.0.4"
       }
     },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+    },
     "is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -5055,6 +5286,11 @@
         "object.assign": "^4.1.3"
       }
     },
+    "kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA=="
+    },
     "language-subtag-registry": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -5106,6 +5342,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5132,6 +5374,60 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "mongodb": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
+      "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
+      "requires": {
+        "bson": "^5.2.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.1"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.1.1.tgz",
+      "integrity": "sha512-AIxaWwGY+td7QOMk4NgK6fbRuGovFyDzv65nU1uj1DsUh3lpjfP3iFYHSR+sUKrs7nbp19ksLlRXkmInBteSCA==",
+      "requires": {
+        "bson": "^5.2.0",
+        "kareem": "2.5.1",
+        "mongodb": "5.3.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
+    },
+    "mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "requires": {
+        "debug": "4.x"
+      }
     },
     "ms": {
       "version": "2.1.2",
@@ -5465,6 +5761,15 @@
         "is-regex": "^1.1.4"
       }
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "sass": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
@@ -5514,15 +5819,43 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socks": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
+    },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "stop-iteration-iterator": {
       "version": "1.0.0",
@@ -5657,6 +5990,14 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -5733,6 +6074,20 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bootstrap": "^5.2.3",
     "eslint": "8.39.0",
     "eslint-config-next": "13.3.1",
+    "mongoose": "^7.1.1",
     "next": "13.3.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/pages/api/bookings/GET.ts
+++ b/src/pages/api/bookings/GET.ts
@@ -1,0 +1,19 @@
+import connectMongo from "../../../util/connectMongo";
+import Booking from "../../../../models/booking";
+
+/**
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+
+export default async function getBookings(req: any, res: any) {
+  try {
+    await connectMongo();
+    const bookings = await Booking.find();
+    res.json({ bookings: bookings });
+    
+  } catch (error) {
+    console.log(error);
+    res.json({ error });
+  }
+}

--- a/src/pages/api/bookings/POST.ts
+++ b/src/pages/api/bookings/POST.ts
@@ -1,0 +1,19 @@
+import connectMongo from "../../../util/connectMongo";
+import Booking from "../../../../models/booking";
+
+/**
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+
+export default async function createBooking(req: any, res: any) {
+  try {
+    await connectMongo();
+    const booking = await Booking.create(req.body);
+    res.json({ booking: booking });
+    
+  } catch (error) {
+    console.log(error);
+    res.json({ error });
+  }
+}

--- a/src/pages/api/movies/GET.ts
+++ b/src/pages/api/movies/GET.ts
@@ -1,0 +1,19 @@
+import connectMongo from "../../../util/connectMongo";
+import Movie from "../../../../models/movie";
+
+/**
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+
+export default async function getMovies(req: any, res: any) {
+  try {
+    await connectMongo();
+    const movies = await Movie.find();
+    res.json({ movies });
+    
+  } catch (error) {
+    console.log(error);
+    res.json({ error });
+  }
+}

--- a/src/pages/api/movies/POST.ts
+++ b/src/pages/api/movies/POST.ts
@@ -1,0 +1,19 @@
+import connectMongo from "../../../util/connectMongo";
+import Movie from "../../../../models/movie";
+
+/**
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+
+export default async function createMovie(req: any, res: any) {
+  try {
+    await connectMongo();
+    const movie = await Movie.create(req.body);
+    res.json({ movie });
+    
+  } catch (error) {
+    console.log(error);
+    res.json({ error });
+  }
+}

--- a/src/pages/api/users/GET.ts
+++ b/src/pages/api/users/GET.ts
@@ -1,0 +1,19 @@
+import connectMongo from "../../../util/connectMongo";
+import User from "../../../../models/user";
+
+/**
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+
+export default async function getUsers(req: any, res: any) {
+  try {
+    await connectMongo();
+    const users = await User.find();
+    res.json({ users: users });
+    
+  } catch (error) {
+    console.log(error);
+    res.json({ error });
+  }
+}

--- a/src/pages/api/users/POST.ts
+++ b/src/pages/api/users/POST.ts
@@ -1,0 +1,19 @@
+import connectMongo from "../../../util/connectMongo";
+import User from "../../../../models/user";
+
+/**
+ * @param {import('next').NextApiRequest} req
+ * @param {import('next').NextApiResponse} res
+ */
+
+export default async function createUser(req: any, res: any) {
+  try {
+    await connectMongo();
+    const user = await User.create(req.body);
+    res.json({ user: user });
+
+  } catch (error) {
+    console.log(error);
+    res.json({ error });
+  }
+}

--- a/src/util/connectMongo.ts
+++ b/src/util/connectMongo.ts
@@ -1,4 +1,4 @@
-import mongoose from 'mongoose';
+import mongoose from "mongoose";
 
 const connectMongo = async () => {
   mongoose.connect(process.env.MONGO_URI as string).catch((error) => {

--- a/src/util/connectMongo.ts
+++ b/src/util/connectMongo.ts
@@ -1,0 +1,12 @@
+import mongoose from "mongoose";
+
+const MONGO_URI =
+  "mongodb://northUser:bGJucFTFliN8qX2Z@ac-gkbjsml-shard-00-00.oxafelt.mongodb.net:27017,ac-gkbjsml-shard-00-01.oxafelt.mongodb.net:27017,ac-gkbjsml-shard-00-02.oxafelt.mongodb.net:27017/?ssl=true&replicaSet=atlas-yrtq9t-shard-0&authSource=admin&retryWrites=true&w=majority";
+
+const connectMongo = async () => {
+  mongoose.connect(MONGO_URI).catch((error) => {
+    console.log(error);
+  });
+};
+
+export default connectMongo;

--- a/src/util/connectMongo.ts
+++ b/src/util/connectMongo.ts
@@ -1,10 +1,7 @@
-import mongoose from "mongoose";
-
-const MONGO_URI =
-  "mongodb://northUser:bGJucFTFliN8qX2Z@ac-gkbjsml-shard-00-00.oxafelt.mongodb.net:27017,ac-gkbjsml-shard-00-01.oxafelt.mongodb.net:27017,ac-gkbjsml-shard-00-02.oxafelt.mongodb.net:27017/?ssl=true&replicaSet=atlas-yrtq9t-shard-0&authSource=admin&retryWrites=true&w=majority";
+import mongoose from 'mongoose';
 
 const connectMongo = async () => {
-  mongoose.connect(MONGO_URI).catch((error) => {
+  mongoose.connect(process.env.MONGO_URI as string).catch((error) => {
     console.log(error);
   });
 };


### PR DESCRIPTION
Database working as intended via cloud with MongoDB ATLAS.

DB collections: Bookings, Users & Movies.

Temporary routes have been made for each Schema/Collection as to initiate them in the ATLAS database, but also for testing to see if they work as intended.

The routes are as follows:
api/collectionName/GET,
api/collectionName/POST

The routes described above are to be deleted later on as the "real" routes described in doc.md(located in rootDir) are implemented continually. But meanwhile they serve as great templates when the "real" routes are created but also to show that the communication with the collections are working properly.

During the codereview, you can use the .JSON-templates in directory:
'models/post_template.json' to create a new Movie/User/Booking with Postman or whatever you prefer. Feel free to change the properties when you are posting so we don't get duplicates. ;)
