### PR TITLE
Add UTC  as zone on date methods to prevent diff

### DIFF
--- a/src/components/AllSpecificMovieScreenings/index.tsx
+++ b/src/components/AllSpecificMovieScreenings/index.tsx
@@ -18,9 +18,8 @@ export default function AllSpecificMovieScreenings({
 }) {
   const [expanded, setExpanded] = useState(false);
 
-  const today = DateTime.now().toISODate();
-  const tomorrow = DateTime.now().plus({ days: 1 }).toISODate();
-
+  const today = DateTime.utc().toISODate();
+  const tomorrow = DateTime.utc().plus({ days: 1 }).toISODate();
   const list = expanded
     ? screenings.screeningsByDay
     : screenings.screeningsByDay.slice(0, 2);
@@ -33,7 +32,7 @@ export default function AllSpecificMovieScreenings({
       <h3>Kommande visningar</h3>
       {list.map((screeningsByDay, index: number) => {
         const dayOfScreening = DateTime.fromISO(
-          screeningsByDay.date
+          screeningsByDay.date, {zone: 'utc'}
         ).toISODate();
         return (
           <div key={index} className={style.dayContainer}>
@@ -43,7 +42,7 @@ export default function AllSpecificMovieScreenings({
                 : tomorrow === dayOfScreening
                 ? "Imorgon"
                 : dayOfScreening !== null &&
-                  DateTime.fromISO(dayOfScreening).toFormat("dd LLL")}
+                  DateTime.fromISO(dayOfScreening, {zone: 'utc'}).toFormat("dd LLL")}
             </h6>
             <ScreeningDay
               movieId={screenings.title}
@@ -53,7 +52,7 @@ export default function AllSpecificMovieScreenings({
         );
       })}
       <button className={style.showMoreButton} onClick={handleClick}>
-        Se fler visningar
+        {expanded? 'Dölj visningar' : 'Se fler visningar'}
       </button>
     </section>
   );

--- a/src/components/Screening/index.tsx
+++ b/src/components/Screening/index.tsx
@@ -30,7 +30,7 @@ export default function Screening({
         {screeningData.title}
       </h3>
       <small className={`${style.date} ${style.cardItem}`}>
-        {DateTime.fromISO(screeningData.screening).toFormat("dd LLL HH:mm")}
+        {DateTime.fromISO(screeningData.screening, {zone: 'utc'}).toFormat("dd LLL HH:mm")}
       </small>
       <small className={`${style.location} ${style.cardItem}`}>
         {screeningData.location}

--- a/src/components/SpecificMovieScreening/index.tsx
+++ b/src/components/SpecificMovieScreening/index.tsx
@@ -58,5 +58,5 @@ function LangComponent({
 }
 // Helper to format time
 function formatTime(time: string) {
-  return `${DateTime.fromISO(time).toFormat("HH:mm")}`;
+  return `${DateTime.fromISO(time, {zone: 'utc'}).toFormat("HH:mm")}`;
 }


### PR DESCRIPTION
## Bugfix

This fixes bugs where the date for screenings displayed on frontend would diff from the value in the database.

This was caused by an involuntary format in the code

Adding `{zone: 'utc'}` to `DateTime.fromISO(text: string, opts: Object)` methods to prevent formatting to `locale` which is set as default if no `zone` is specified.

